### PR TITLE
support hideTabBar on nested scenes

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -324,11 +324,14 @@ function createNavigationOptions(params) {
 
     // currect dynamic navigation params has priority over static scene params
     // but taking them into account only if they are explicitly set (not null or undefined)
+    const routeParams = navigation.state.routes && navigation.state.routes[navigation.state.index].params;
     if (navigationParams.hideTabBar != null) {
       if (navigationParams.hideTabBar) {
         res.tabBarVisible = false;
       }
     } else if (hideTabBar) {
+      res.tabBarVisible = false;
+    } else if (routeParams && routeParams.hideTabBar) {
       res.tabBarVisible = false;
     }
 


### PR DESCRIPTION
In React Navigation 2.x the feature to hide the tab bar was changed, ref: https://github.com/react-navigation/react-navigation-tabs/issues/19

This pull request makes it possible to hide the tab bar from nested scenes, as long as the scene(s) is wrapped in a `<Stack hideTabBar />` component (note that the `hideTabBar` prop have to be set on the stack component, not the scene component). 

I have not thoroughly tested this PR, but it works for our simple case. 

I'm not sure if this is the correct approach / solution to the problem, but we'd like to solve this issue some time soon. Let me know if I can be of any other assistance. 


ref: #3293