### PR TITLE
add hideTabBar Type for StackProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,7 @@ interface StackProps extends React.Props<Stack> {
   icon?: any;
   tintColor?: string;
   hideNavBar?: boolean;
+  hideTabBar?: boolean;
   title?: string;
   titleStyle?: StyleProp<TextStyle>;
 }


### PR DESCRIPTION
Based on https://github.com/RNRF/react-native-router-flux/pull/3315 Stack should support hideTabBar props. 