### PR TITLE
handle transparency and inherited duration

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -652,8 +652,7 @@ class NavigationStore {
           duration,
           timing: Animated.timing,
           easing: Easing.step0,
-        },
-        containerStyle: {},
+        }
       });
     }
 

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -646,15 +646,21 @@ class NavigationStore {
       overlay = true;
     }
 
-    if (duration !== undefined && !transitionConfig) {
+    if ((inheritProps.duration !== undefined || duration !== undefined) && !transitionConfig) {
       transitionConfig = () => ({
         transitionSpec: {
           duration,
           timing: Animated.timing,
           easing: Easing.step0,
         },
+        containerStyle: {},
       });
     }
+
+    transparnetTransitionConfig = () => ({
+      ...(transitionConfig ? transitionConfig() : {}),
+      containerStyle: {},
+    });
 
     const commonProps = { ...inheritProps, ...parentProps };
     delete commonProps.children;
@@ -881,7 +887,7 @@ class NavigationStore {
       initialRouteParams,
       initialRouteName,
       ...commonProps,
-      transitionConfig,
+      transitionConfig: transparnetTransitionConfig,
       navigationOptions: createNavigationOptions(commonProps),
     });
   };


### PR DESCRIPTION
this PR solves two problems:

1.  backgoundColor black out when 'transparent' specified
2. `duration` is not considered as Router attributes

I encounter these problems when I use RNRF without transition and with transparent background.

related: https://github.com/react-navigation/react-navigation/issues/2713#issuecomment-338414647