### PR TITLE
Added missing indicatorStyle to TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,7 @@ interface TabsProps extends React.Props<Tabs> {
   tabBarPosition?: TabBarPositionType;
   tabBarStyle?: StyleProp<ViewStyle>;
   tabStyle?: StyleProp<ViewStyle>;
+  indicatorStyle?: StyleProp<ViewStyle>;
   showLabel?: boolean;
   swipeEnabled?: boolean;
   tabBarOnPress?: Function;


### PR DESCRIPTION
Tabs component has `indicatorStyle` actually, but it is missing in TypeScript definition (`index.d.ts`).