### PR TITLE
Fix tab bar position cannot be changed

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -838,6 +838,7 @@ class NavigationStore {
         tabBarComponent,
         initialRouteName,
         initialRouteParams,
+        tabBarPosition,
         order,
         ...commonProps,
         tabBarOptions: createTabBarOptions(commonProps),


### PR DESCRIPTION
Fix tab bar position with props legacy cannot be changed with props tabBarPosition.